### PR TITLE
[Feat]: 위치 인증 서비스 로직 구현 및 거리 계산 기능 추가

### DIFF
--- a/src/main/java/com/kangwon/fino/service/LocationAuthService.java
+++ b/src/main/java/com/kangwon/fino/service/LocationAuthService.java
@@ -1,0 +1,16 @@
+package com.kangwon.fino.service;
+
+import com.kangwon.fino.dto.LocationAuthRequest;
+import com.kangwon.fino.dto.LocationAuthResponse;
+
+public interface LocationAuthService {
+    /**
+     * 사용자의 현재 위치를 기반으로 인증을 수행합니다.
+     * 사용자의 등록된 기준 위치와 클라이언트가 전송한 현재 위치 간의 거리를 계산하여
+     * 허용된 오차 범위 내에 있는지 확인합니다.
+     *
+     * @param request 위치 인증 요청 DTO (사용자 ID, 현재 위도/경도 포함)
+     * @return 위치 인증 결과 응답 DTO (인증 성공 여부, 메시지 포함)
+     */
+    LocationAuthResponse authenticateByLocation(LocationAuthRequest request);
+}

--- a/src/main/java/com/kangwon/fino/service/LocationAuthServiceImpl.java
+++ b/src/main/java/com/kangwon/fino/service/LocationAuthServiceImpl.java
@@ -1,0 +1,88 @@
+package com.kangwon.fino.service;
+
+import com.kangwon.fino.domain.TblUser;
+import com.kangwon.fino.dto.LocationAuthRequest;
+import com.kangwon.fino.dto.LocationAuthResponse;
+import com.kangwon.fino.repository.TblUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LocationAuthServiceImpl implements LocationAuthService {
+
+    private final TblUserRepository tblUserRepository; // UserRepository 주입
+
+    // 허용 오차 범위 (미터 단위)
+    private static final double ALLOWED_DISTANCE_METERS = 150.0;
+
+    @Override
+    public LocationAuthResponse authenticateByLocation(LocationAuthRequest request) {
+        // 1. 사용자 ID로 TblUser 조회
+        Optional<TblUser> userOptional = tblUserRepository.findById(request.getUserId());
+
+        if (userOptional.isEmpty()) {
+            return LocationAuthResponse.builder()
+                    .isAuthenticated(false)
+                    .message("사용자를 찾을 수 없습니다.")
+                    .build();
+        }
+
+        TblUser user = userOptional.get();
+
+        // 사용자의 등록된 기준 위치가 없으면 인증 불가
+        if (user.getLatitude() == null || user.getLongitude() == null) {
+            return LocationAuthResponse.builder()
+                    .isAuthenticated(false)
+                    .message("사용자의 등록된 기준 위치 정보가 없습니다.")
+                    .build();
+        }
+
+        // 2. 클라이언트 현재 위치와 사용자 등록 위치 간의 거리 계산
+        double distance = calculateDistance(
+                user.getLatitude(), user.getLongitude(),
+                request.getLatitude(), request.getLongitude()
+        );
+
+        // 3. 거리 비교 및 인증 판단
+        if (distance <= ALLOWED_DISTANCE_METERS) {
+            return LocationAuthResponse.builder()
+                    .isAuthenticated(true)
+                    .message("위치 인증 성공! 허용 범위 내에 있습니다. (거리: " + String.format("%.2f", distance) + "m)")
+                    .build();
+        } else {
+            return LocationAuthResponse.builder()
+                    .isAuthenticated(false)
+                    .message("위치 인증 실패. 허용 범위를 벗어났습니다. (거리: " + String.format("%.2f", distance) + "m)")
+                    .build();
+        }
+    }
+
+    /**
+     * 두 위경도 지점 간의 거리를 미터 단위로 계산합니다. (하버사인 공식)
+     * 위도/경도는 도(degree) 단위로 입력되어야 합니다.
+     *
+     * @param lat1 첫 번째 지점의 위도
+     * @param lon1 첫 번째 지점의 경도
+     * @param lat2 두 번째 지점의 위도
+     * @param lon2 두 번째 지점의 경도
+     * @return 두 지점 간의 거리 (미터)
+     */
+    private double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        final int R = 6371000; // 지구의 반지름 (미터)
+
+        double latDistance = Math.toRadians(lat2 - lat1);
+        double lonDistance = Math.toRadians(lon2 - lon1);
+
+        double a = Math.sin(latDistance / 2) * Math.sin(latDistance / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(lonDistance / 2) * Math.sin(lonDistance / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return R * c; // 미터 단위 거리
+    }
+}


### PR DESCRIPTION
## 코드 변경 이유
- 위치 기반 사용자 인증 기능을 위한 핵심 비즈니스 로직을 구현하기 위함
- 사용자가 전송한 현재 위치와 시스템에 등록된 사용자의 기준 위치 간의 실제 거리를 계산하여 인증 여부를 판단

<br>

## 구현 사항
- com.kangwon.fino.service 패키지 생성
- LocationAuthService (인터페이스) 및 LocationAuthServiceImpl (구현체) 정의
- LocationAuthServiceImpl 내부에 다음 로직 구현:
    - TblUserRepository를 통해 사용자(TblUser) 정보 조회
    - 하버사인(Haversine) 공식을 사용하여 두 위경도(TblUser의 위치, 요청 DTO의 현재 위치) 간의 거리(calculateDistance 메서드) 계산
    - 계산된 거리가 ALLOWED_DISTANCE_METERS (현재 150m) 이내인지 확인하여 LocationAuthResponse 반환
    - 사용자 미 발견 또는 등록된 위치 정보 없음 등의 예외 처리 포함

<br>

## 발견 위험/장애
- 초기 ALLOWED_DISTANCE_METERS 값이 50m로 설정되었으나, 현실적인 사용 시나리오를 고려하여 150m로 수정
- 허용 오차 범위(ALLOWED_DISTANCE_METERS)는 추후 설정 파일(application.yml/properties)에서 관리하도록 리팩토링이 필요할 수 있음

<br>

## 테스트 완료 및 계획
- 추후 위치 기반 사용자 인증 기능이 완성되면 테스트 진행할 예정

<br>

## To Reviewers
- 코드가 적합한지 확인 부탁

---
**Closes #10**