### PR TITLE
[Feat]: 위치 인증 API 엔드포인트 추가

### DIFF
--- a/src/main/java/com/kangwon/fino/controller/LocationAuthController.java
+++ b/src/main/java/com/kangwon/fino/controller/LocationAuthController.java
@@ -1,0 +1,41 @@
+package com.kangwon.fino.controller;
+
+import com.kangwon.fino.dto.LocationAuthRequest;
+import com.kangwon.fino.dto.LocationAuthResponse;
+import com.kangwon.fino.service.LocationAuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth/location")
+@RequiredArgsConstructor
+public class LocationAuthController {
+
+    private final LocationAuthService locationAuthService;
+
+    /**
+     * 사용자의 위치 인증을 요청하는 API 엔드포인트.
+     * 클라이언트로부터 위치 인증 요청 DTO를 받아 서비스 로직을 수행하고 결과를 반환
+     *
+     * @param request 위치 인증 요청 DTO (JSON 형식의 요청 바디)
+     * @return 위치 인증 결과 응답 DTO와 HTTP 상태 코드를 포함하는 ResponseEntity
+     */
+    @PostMapping
+    public ResponseEntity<LocationAuthResponse> authenticateLocation(@RequestBody LocationAuthRequest request) {
+        // 서비스 계층의 비즈니스 로직 호출
+        LocationAuthResponse response = locationAuthService.authenticateByLocation(request);
+
+        // 서비스 결과에 따라 적절한 HTTP 상태 코드와 함께 응답 반환
+        if (response.isAuthenticated()) {
+            return ResponseEntity.ok(response); // HTTP 200 OK
+        } else {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response); // HTTP 400 Bad Request
+        }
+    }
+
+}


### PR DESCRIPTION
## 코드 변경 이유
- '위치 기반 사용자 인증' 기능을 클라이언트에서 호출할 수 있도록 RESTful API 엔드포인트를 구현하기 위함
- 클라이언트의 요청을 받아 서비스 계층으로 전달하고, 서비스 계층의 결과를 클라이언트에게 HTTP 응답으로 반환하는 역할을 수행

<br>

## 구현 사항
- com.kangwon.fino.controller 패키지 생성 및 LocationAuthController.java 클래스 정의
- @RestController 및 @RequestMapping("/api/v1/auth/location") 어노테이션을 사용하여 API 엔드포인트 설정
- LocationAuthService를 주입받아 비즈니스 로직 호출
- POST /api/v1/auth/location 엔드포인트에 매핑되는 authenticateLocation 메서드 구현
    - @RequestBody를 통해 LocationAuthRequest DTO를 요청 바디로 수신
    - locationAuthService.authenticateByLocation() 호출하여 인증 수행
    - 인증 결과(LocationAuthResponse)에 따라 ResponseEntity와 적절한 HTTP 상태 코드 반환

<br>

## 발견 위험/장애
- DTO 유효성 검사 없음
- 예외 처리 없음

<br>

## 테스트 완료 및 계획
- 추후 위치 기반 사용자 인증 기능이 완성되면 테스트 진행할 예정

<br>

## To Reviewers
- 코드가 적합한지 확인 부탁

---
**Closes #12**